### PR TITLE
Fix arena HUD position

### DIFF
--- a/src/components/Game/SnakeGame.css
+++ b/src/components/Game/SnakeGame.css
@@ -692,10 +692,8 @@
 
 /* Game HUD Styles */
 .game-hud {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  /* Use relative positioning so the game board is pushed below the HUD */
+  position: relative;
   z-index: 10;
   pointer-events: none;
   padding: 10px;


### PR DESCRIPTION
## Summary
- avoid overlaying the game board with HUD

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6878be98eb4c83299f29db0f9269d0f5