### PR TITLE
Improve level 3 bot intelligence

### DIFF
--- a/src/utils/GameUtils.ts
+++ b/src/utils/GameUtils.ts
@@ -242,3 +242,32 @@ export const moveInDirection = (position: Position, direction: Direction): Posit
     case 'RIGHT': return { x: position.x + 1, y: position.y };
   }
 };
+
+// Calculate how much open space can be reached from a start position using
+// a simple flood fill. This is used by AI routines to estimate how "safe" a
+// potential move is. A larger returned value means the position has more
+// available cells before hitting walls or other snakes.
+export const floodFillArea = (
+  start: Position,
+  obstacles: Position[],
+  boardSize: number
+): number => {
+  const visited = new Set<string>();
+  const queue: Position[] = [start];
+  visited.add(`${start.x},${start.y}`);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const neighbors = getAdjacentPositions(current, boardSize);
+
+    for (const n of neighbors) {
+      const key = `${n.x},${n.y}`;
+      if (visited.has(key)) continue;
+      if (obstacles.some(o => positionEquals(o, n))) continue;
+      visited.add(key);
+      queue.push(n);
+    }
+  }
+
+  return visited.size;
+};


### PR DESCRIPTION
## Summary
- add a flood fill helper for measuring free space
- use flood fill and scoring in level 3 bot AI to pick smarter moves
- fix lint errors by removing unused imports
- fix food reset bug when spawning power-ups

## Testing
- `npm test --silent --runTestsByPath src/App.test.tsx`
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878f563afe48329afd5234031a1a1d7