### PR TITLE
Add particle effects and enhanced menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,3 +125,25 @@
   color: black;
   transform: scale(1.05);
 }
+
+.enhanced-back-button {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  padding: 10px 15px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: var(--primary-color, #00ff88);
+  border: 2px solid var(--primary-color, #00ff88);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  z-index: 9999;
+  transition: all 0.3s ease;
+}
+
+.enhanced-back-button:hover {
+  background-color: var(--primary-color, #00ff88);
+  color: #000;
+  transform: scale(1.05);
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,5 +4,5 @@ import App from './App';
 
 test('renders game menu', () => {
   render(<App />);
-  expect(screen.getByText(/snake game/i)).toBeInTheDocument();
+  expect(screen.getByText(/snake evolution/i)).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,74 +1,72 @@
-// src/App.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SnakeGame from './components/Game/SnakeGame';
 import SnakeGameLevel2 from './components/Game/SnakeGameLevel2';
 import SnakeGameLevel3 from './components/Game/SnakeGameLevel3';
+import TutorialMode from './components/Game/TutorialMode';
+import { EnhancedMenu } from './components/Menu/EnhancedMenu';
 import './App.css';
 
-type GameMode = 'menu' | 'level1' | 'level2' | 'level3';
+type GameMode = 'menu' | 'level1' | 'level2' | 'level3' | 'tutorial';
 
 function App() {
   const [gameMode, setGameMode] = useState<GameMode>('menu');
+  const [particlesEnabled, setParticlesEnabled] = useState(true);
+  const [soundEnabled, setSoundEnabled] = useState(true);
 
-  const renderModeSelector = () => (
-    <div className="app-container">
-      <div className="menu-container">
-        <h1>🐍 Snake Game 🐍</h1>
-        <h2>Choose Your Level</h2>
-        
-        <button
-          onClick={() => setGameMode('level1')}
-          className="menu-button"
-        >
-          <div className="button-title">🎯 Level 1: Classic</div>
-          <div className="button-description">The timeless snake experience</div>
-        </button>
+  // Load settings
+  useEffect(() => {
+    const savedParticles = localStorage.getItem('snakeParticlesEnabled');
+    setParticlesEnabled(savedParticles !== 'false');
+    
+    const savedSound = localStorage.getItem('snakeSoundEnabled');
+    setSoundEnabled(savedSound !== 'false');
+  }, []);
 
-        <button
-          onClick={() => setGameMode('level2')}
-          className="menu-button"
-        >
-          <div className="button-title">🧱 Level 2: Obstacles</div>
-          <div className="button-description">Navigate through walls and barriers</div>
-        </button>
-
-        <button
-          onClick={() => setGameMode('level3')}
-          className="menu-button"
-        >
-          <div className="button-title">🤖 Level 3: Bot Battle</div>
-          <div className="button-description">Face off against AI with power-ups!</div>
-        </button>
-        
-        <div className="feature-box">
-          <h3>New Features!</h3>
-          <ul>
-            <li>🧱 Level 2: Smart obstacle placement</li>
-            <li>🤖 Level 3: AI opponent with strategy</li>
-            <li>⚡ Power-ups: Speed, invincibility, and more!</li>
-            <li>🏆 Score multipliers and special effects</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  );
+  const handleModeSelect = (mode: 'level1' | 'level2' | 'level3' | 'tutorial') => {
+    setGameMode(mode);
+  };
 
   const renderBackButton = () => (
     <button
       onClick={() => setGameMode('menu')}
-      className="back-button"
+      className="enhanced-back-button"
     >
-      ← Back to Menu
+      <span className="back-arrow">←</span>
+      <span className="back-text">Menu</span>
     </button>
   );
 
   return (
     <div className="App">
-      {gameMode === 'menu' && renderModeSelector()}
+      {gameMode === 'menu' && (
+        <EnhancedMenu onSelectMode={handleModeSelect} />
+      )}
       {gameMode !== 'menu' && renderBackButton()}
-      {gameMode === 'level1' && <SnakeGame />}
-      {gameMode === 'level2' && <SnakeGameLevel2 />}
-      {gameMode === 'level3' && <SnakeGameLevel3 />}
+      {gameMode === 'level1' && (
+        <SnakeGame 
+          particlesEnabled={particlesEnabled} 
+          soundEnabled={soundEnabled} 
+        />
+      )}
+      {gameMode === 'level2' && (
+        <SnakeGameLevel2 
+          particlesEnabled={particlesEnabled} 
+          soundEnabled={soundEnabled} 
+        />
+      )}
+      {gameMode === 'level3' && (
+        <SnakeGameLevel3 
+          particlesEnabled={particlesEnabled} 
+          soundEnabled={soundEnabled} 
+        />
+      )}
+      {gameMode === 'tutorial' && (
+        <TutorialMode 
+          onComplete={() => setGameMode('menu')}
+          particlesEnabled={particlesEnabled} 
+          soundEnabled={soundEnabled} 
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Effects/ParticleSystem.css
+++ b/src/components/Effects/ParticleSystem.css
@@ -1,0 +1,170 @@
+.particle-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 50;
+  will-change: transform;
+}
+
+/* Screen shake animation */
+@keyframes shake {
+  0%, 100% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  10% {
+    transform: translate(-2px, -2px) rotate(-0.5deg);
+  }
+  20% {
+    transform: translate(2px, -2px) rotate(0.5deg);
+  }
+  30% {
+    transform: translate(-2px, 2px) rotate(-0.5deg);
+  }
+  40% {
+    transform: translate(2px, 2px) rotate(0.5deg);
+  }
+  50% {
+    transform: translate(-1px, -1px) rotate(-0.25deg);
+  }
+  60% {
+    transform: translate(1px, -1px) rotate(0.25deg);
+  }
+  70% {
+    transform: translate(-1px, 1px) rotate(-0.25deg);
+  }
+  80% {
+    transform: translate(1px, 1px) rotate(0.25deg);
+  }
+  90% {
+    transform: translate(0, -1px) rotate(0deg);
+  }
+}
+
+.particle-canvas.shake {
+  animation: shake 0.3s ease-in-out;
+}
+
+/* Combo text animation */
+@keyframes comboFloat {
+  0% {
+    transform: translateY(0) scale(0.5);
+    opacity: 0;
+  }
+  20% {
+    transform: translateY(-10px) scale(1.2);
+    opacity: 1;
+  }
+  80% {
+    transform: translateY(-40px) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-60px) scale(0.8);
+    opacity: 0;
+  }
+}
+
+.combo-text {
+  position: absolute;
+  font-size: 24px;
+  font-weight: bold;
+  color: #FFD700;
+  text-shadow: 
+    0 0 10px #FFD700,
+    0 0 20px #FFD700,
+    0 0 30px #FFD700;
+  animation: comboFloat 1.5s ease-out forwards;
+  pointer-events: none;
+  z-index: 60;
+}
+
+/* Score popup animation */
+@keyframes scorePopup {
+  0% {
+    transform: scale(0) rotate(0deg);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.2) rotate(5deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) rotate(0deg) translateY(-20px);
+    opacity: 0;
+  }
+}
+
+.score-popup {
+  position: absolute;
+  font-size: 18px;
+  font-weight: bold;
+  color: #00ff88;
+  text-shadow: 
+    0 0 5px #00ff88,
+    0 0 10px #00ff88;
+  animation: scorePopup 1s ease-out forwards;
+  pointer-events: none;
+  z-index: 60;
+}
+
+/* Power-up collection effect */
+@keyframes powerupCollect {
+  0% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(2) rotate(180deg);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(0) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.powerup-collect-effect {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  animation: powerupCollect 0.6s ease-out forwards;
+  pointer-events: none;
+  z-index: 55;
+}
+
+/* Snake trail effect */
+.snake-trail {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 5;
+  opacity: 0.3;
+  animation: fadeOut 0.5s ease-out forwards;
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+}
+
+/* Glow effects for enhanced visuals */
+.glow-effect {
+  filter: drop-shadow(0 0 10px currentColor);
+}
+
+.pulse-glow {
+  animation: pulseGlow 2s infinite alternate;
+}
+
+@keyframes pulseGlow {
+  0% {
+    filter: drop-shadow(0 0 5px currentColor);
+  }
+  100% {
+    filter: drop-shadow(0 0 20px currentColor);
+  }
+}

--- a/src/components/Effects/ParticleSystem.tsx
+++ b/src/components/Effects/ParticleSystem.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './ParticleSystem.css';
+
+export interface Particle {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  color: string;
+  life: number;
+  maxLife: number;
+  type: 'food' | 'collision' | 'powerup' | 'trail' | 'combo';
+}
+
+interface ParticleSystemProps {
+  boardSize: number;
+  cellSize: number;
+}
+
+export const ParticleSystem: React.FC<ParticleSystemProps> = ({ boardSize, cellSize }) => {
+  const [particles, setParticles] = useState<Particle[]>([]);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const lastTimeRef = useRef<number>(0);
+
+  // Particle emitter functions
+  const createParticle = (
+    x: number,
+    y: number,
+    type: Particle['type'],
+    color: string = '#fff'
+  ): Particle => {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = type === 'trail' ? 0.5 : 2 + Math.random() * 3;
+    const size = type === 'trail' ? 2 + Math.random() * 2 : 3 + Math.random() * 4;
+    
+    return {
+      id: `${Date.now()}-${Math.random()}`,
+      x: x * cellSize + cellSize / 2,
+      y: y * cellSize + cellSize / 2,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      size,
+      color,
+      life: 1,
+      maxLife: type === 'trail' ? 0.3 : 0.6 + Math.random() * 0.4,
+      type
+    };
+  };
+
+  // Public methods exposed through window
+  useEffect(() => {
+    const particleAPI = {
+      emitFoodParticles: (x: number, y: number) => {
+        const newParticles: Particle[] = [];
+        for (let i = 0; i < 8; i++) {
+          newParticles.push(createParticle(x, y, 'food', '#ff4444'));
+        }
+        setParticles(prev => [...prev, ...newParticles]);
+      },
+      
+      emitCollisionParticles: (x: number, y: number, color: string = '#00ff88') => {
+        const newParticles: Particle[] = [];
+        for (let i = 0; i < 15; i++) {
+          newParticles.push(createParticle(x, y, 'collision', color));
+        }
+        setParticles(prev => [...prev, ...newParticles]);
+        
+        // Screen shake effect
+        if (canvasRef.current) {
+          canvasRef.current.classList.add('shake');
+          setTimeout(() => {
+            canvasRef.current?.classList.remove('shake');
+          }, 300);
+        }
+      },
+      
+      emitPowerUpParticles: (x: number, y: number, color: string) => {
+        const newParticles: Particle[] = [];
+        for (let i = 0; i < 20; i++) {
+          const particle = createParticle(x, y, 'powerup', color);
+          particle.size *= 1.5;
+          particle.maxLife *= 1.5;
+          newParticles.push(particle);
+        }
+        setParticles(prev => [...prev, ...newParticles]);
+      },
+      
+      emitTrailParticle: (x: number, y: number, color: string) => {
+        const particle = createParticle(x, y, 'trail', color);
+        particle.vx *= 0.1;
+        particle.vy *= 0.1;
+        setParticles(prev => [...prev, particle]);
+      },
+      
+      emitComboParticles: (x: number, y: number, comboCount: number) => {
+        const colors = ['#FFD700', '#FF6347', '#9370DB', '#00CED1'];
+        const newParticles: Particle[] = [];
+        
+        for (let i = 0; i < comboCount * 5; i++) {
+          const particle = createParticle(x, y, 'combo', colors[i % colors.length]);
+          particle.size *= 1.2;
+          particle.vx *= 1.5;
+          particle.vy *= 1.5;
+          newParticles.push(particle);
+        }
+        setParticles(prev => [...prev, ...newParticles]);
+      }
+    };
+
+    // Expose to window for other components to use
+    (window as any).particleSystem = particleAPI;
+
+    return () => {
+      delete (window as any).particleSystem;
+    };
+  }, [cellSize]);
+
+  // Animation loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const animate = (currentTime: number) => {
+      const deltaTime = (currentTime - lastTimeRef.current) / 1000;
+      lastTimeRef.current = currentTime;
+
+      // Clear canvas
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // Update and draw particles
+      setParticles(prevParticles => {
+        return prevParticles.filter(particle => {
+          // Update particle physics
+          particle.x += particle.vx;
+          particle.y += particle.vy;
+          particle.life -= deltaTime / particle.maxLife;
+          
+          // Apply gravity for some particles
+          if (particle.type !== 'trail') {
+            particle.vy += 0.2;
+          }
+          
+          // Fade out
+          const alpha = Math.max(0, particle.life);
+          
+          // Draw particle
+          ctx.save();
+          ctx.globalAlpha = alpha;
+          
+          if (particle.type === 'trail') {
+            // Draw trail as soft circle
+            const gradient = ctx.createRadialGradient(
+              particle.x, particle.y, 0,
+              particle.x, particle.y, particle.size
+            );
+            gradient.addColorStop(0, particle.color);
+            gradient.addColorStop(1, 'transparent');
+            ctx.fillStyle = gradient;
+          } else {
+            // Draw other particles with glow effect
+            ctx.shadowBlur = particle.size * 2;
+            ctx.shadowColor = particle.color;
+            ctx.fillStyle = particle.color;
+          }
+          
+          ctx.beginPath();
+          ctx.arc(particle.x, particle.y, particle.size * alpha, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.restore();
+          
+          // Keep particle if still alive
+          return particle.life > 0;
+        });
+      });
+
+      animationRef.current = requestAnimationFrame(animate);
+    };
+
+    animationRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, []);
+
+  // Update canvas size
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const size = boardSize * cellSize + 16; // Include padding
+    canvas.width = size;
+    canvas.height = size;
+  }, [boardSize, cellSize]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="particle-canvas"
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        pointerEvents: 'none',
+        zIndex: 50
+      }}
+    />
+  );
+};

--- a/src/components/Game/TutorialMode.tsx
+++ b/src/components/Game/TutorialMode.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface TutorialModeProps {
+  onComplete: () => void;
+  particlesEnabled: boolean;
+  soundEnabled: boolean;
+}
+
+const TutorialMode: React.FC<TutorialModeProps> = ({ onComplete }) => {
+  return (
+    <div style={{ padding: '20px', textAlign: 'center', color: '#fff' }}>
+      <h2>Tutorial Mode</h2>
+      <p>This is a placeholder for the interactive tutorial.</p>
+      <button onClick={onComplete}>Return to Menu</button>
+    </div>
+  );
+};
+
+export default TutorialMode;

--- a/src/components/Menu/EnhancedMenu.css
+++ b/src/components/Menu/EnhancedMenu.css
@@ -1,0 +1,518 @@
+:root {
+  --primary-color: #00ff88;
+  --secondary-color: #ff4444;
+  --accent-color: #ffaa00;
+  --background-color: #111;
+}
+
+.enhanced-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--background-color);
+  overflow: hidden;
+}
+
+.menu-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.5;
+}
+
+.menu-content {
+  position: relative;
+  z-index: 10;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  backdrop-filter: blur(10px);
+  background: rgba(0, 0, 0, 0.5);
+}
+
+/* Header Styles */
+.menu-header {
+  text-align: center;
+  margin-bottom: 40px;
+  animation: slideDown 0.8s ease-out;
+}
+
+.game-title {
+  font-size: clamp(2.5rem, 8vw, 4rem);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  color: var(--primary-color);
+  text-shadow: 
+    0 0 20px var(--primary-color),
+    0 0 40px var(--primary-color),
+    0 0 60px var(--primary-color);
+  animation: titleGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes titleGlow {
+  0% {
+    text-shadow: 
+      0 0 20px var(--primary-color),
+      0 0 40px var(--primary-color);
+  }
+  100% {
+    text-shadow: 
+      0 0 30px var(--primary-color),
+      0 0 60px var(--primary-color),
+      0 0 90px var(--primary-color);
+  }
+}
+
+.snake-icon {
+  font-size: 1.2em;
+  animation: bounce 1.5s ease-in-out infinite;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-10px) rotate(10deg);
+  }
+}
+
+.game-subtitle {
+  font-size: clamp(1rem, 3vw, 1.3rem);
+  color: var(--accent-color);
+  margin: 10px 0 0 0;
+  opacity: 0.8;
+}
+
+/* Level Cards */
+.level-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  max-width: 900px;
+  width: 100%;
+  margin-bottom: 30px;
+}
+
+.level-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+  border: 2px solid var(--primary-color);
+  border-radius: 20px;
+  padding: 30px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+  animation: fadeIn 0.6s ease-out;
+  animation-fill-mode: both;
+  position: relative;
+  overflow: hidden;
+}
+
+.level-card:nth-child(1) { animation-delay: 0.1s; }
+.level-card:nth-child(2) { animation-delay: 0.2s; }
+.level-card:nth-child(3) { animation-delay: 0.3s; }
+
+.level-card::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle, var(--primary-color) 0%, transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.level-card:hover {
+  transform: translateY(-10px) scale(1.02);
+  box-shadow: 
+    0 10px 30px rgba(0, 255, 136, 0.3),
+    inset 0 0 20px rgba(0, 255, 136, 0.1);
+  border-color: var(--accent-color);
+}
+
+.level-card:hover::before {
+  opacity: 0.1;
+}
+
+.card-icon {
+  font-size: 3rem;
+  margin-bottom: 15px;
+  animation: float 3s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+.level-card h3 {
+  color: var(--primary-color);
+  font-size: 1.5rem;
+  margin: 0 0 10px 0;
+}
+
+.level-card p {
+  color: #ccc;
+  margin: 0 0 15px 0;
+  font-size: 0.9rem;
+}
+
+.high-score {
+  color: var(--accent-color);
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+/* Menu Actions */
+.menu-actions {
+  display: flex;
+  gap: 15px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.menu-button {
+  padding: 12px 30px;
+  border: 2px solid var(--primary-color);
+  background: linear-gradient(135deg, rgba(0, 255, 136, 0.1), rgba(0, 255, 136, 0.05));
+  color: var(--primary-color);
+  border-radius: 30px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: fadeIn 0.8s ease-out;
+}
+
+.menu-button:hover {
+  background: var(--primary-color);
+  color: var(--background-color);
+  transform: scale(1.05);
+  box-shadow: 0 5px 20px rgba(0, 255, 136, 0.4);
+}
+
+.btn-icon {
+  font-size: 1.2rem;
+}
+
+/* Quick Stats */
+.quick-stats {
+  display: flex;
+  gap: 30px;
+  animation: slideUp 0.8s ease-out;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+}
+
+.stat-icon {
+  font-size: 2rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--primary-color);
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: #888;
+  text-transform: uppercase;
+}
+
+/* Settings Panel */
+.settings-panel, .stats-panel, .tutorial-panel {
+  background: rgba(0, 0, 0, 0.8);
+  border: 2px solid var(--primary-color);
+  border-radius: 20px;
+  padding: 40px;
+  max-width: 800px;
+  width: 100%;
+  animation: fadeIn 0.5s ease-out;
+}
+
+.settings-section {
+  margin-bottom: 30px;
+}
+
+.settings-section h3 {
+  color: var(--primary-color);
+  margin-bottom: 15px;
+}
+
+.theme-selector {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.theme-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 10px;
+  border-radius: 10px;
+  transition: all 0.2s ease;
+}
+
+.theme-option:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.theme-option.active {
+  background: rgba(0, 255, 136, 0.2);
+  border: 1px solid var(--primary-color);
+}
+
+.theme-preview {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.toggle-button {
+  padding: 8px 20px;
+  border: 2px solid var(--primary-color);
+  background: transparent;
+  color: var(--primary-color);
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: bold;
+}
+
+.toggle-button.active {
+  background: var(--primary-color);
+  color: var(--background-color);
+}
+
+/* Stats Panel */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--primary-color);
+  border-radius: 15px;
+  padding: 20px;
+  text-align: center;
+}
+
+.stat-card h3 {
+  color: #888;
+  font-size: 0.9rem;
+  margin: 0 0 10px 0;
+}
+
+.stat-number {
+  font-size: 2rem;
+  font-weight: bold;
+  color: var(--accent-color);
+}
+
+/* Achievements */
+.achievements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 15px;
+}
+
+.achievement-card {
+  display: flex;
+  gap: 15px;
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  transition: all 0.2s ease;
+}
+
+.achievement-card.unlocked {
+  border-color: var(--accent-color);
+  background: rgba(255, 170, 0, 0.1);
+}
+
+.achievement-card.locked {
+  opacity: 0.5;
+  filter: grayscale(100%);
+}
+
+.achievement-icon {
+  font-size: 2rem;
+}
+
+.achievement-info h4 {
+  color: var(--primary-color);
+  margin: 0 0 5px 0;
+  font-size: 1rem;
+}
+
+.achievement-info p {
+  color: #888;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+/* Tutorial Panel */
+.tutorial-content {
+  margin-bottom: 30px;
+}
+
+.tutorial-section {
+  margin-bottom: 25px;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+}
+
+.tutorial-section h3 {
+  color: var(--primary-color);
+  margin: 0 0 15px 0;
+}
+
+.tutorial-section p {
+  margin: 8px 0;
+  color: #ccc;
+}
+
+.powerup-list p {
+  margin: 10px 0;
+  padding-left: 20px;
+}
+
+.play-tutorial {
+  background: linear-gradient(135deg, var(--accent-color), var(--secondary-color));
+  border-color: var(--accent-color);
+  color: white;
+  font-size: 1.2rem;
+  padding: 15px 40px;
+  margin: 0 auto;
+}
+
+.play-tutorial:hover {
+  transform: scale(1.1);
+  box-shadow: 0 8px 30px rgba(255, 170, 0, 0.5);
+}
+
+/* Back Button */
+.back-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #888;
+  padding: 10px 20px;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-top: 20px;
+}
+
+.back-btn:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  .game-title {
+    font-size: 2rem;
+    gap: 10px;
+  }
+  
+  .level-cards {
+    grid-template-columns: 1fr;
+  }
+  
+  .menu-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+  
+  .menu-button {
+    width: 100%;
+    justify-content: center;
+  }
+  
+  .quick-stats {
+    gap: 20px;
+  }
+  
+  .settings-panel, .stats-panel, .tutorial-panel {
+    padding: 20px;
+  }
+}

--- a/src/components/Menu/EnhancedMenu.tsx
+++ b/src/components/Menu/EnhancedMenu.tsx
@@ -1,0 +1,436 @@
+import React, { useState, useEffect, useRef } from 'react';
+import './EnhancedMenu.css';
+
+interface EnhancedMenuProps {
+  onSelectMode: (mode: 'level1' | 'level2' | 'level3' | 'tutorial') => void;
+}
+
+interface GameStats {
+  gamesPlayed: number;
+  highScores: {
+    level1: number;
+    level2: number;
+    level3: number;
+  };
+  totalFoodEaten: number;
+  totalPowerUpsCollected: number;
+  achievements: string[];
+}
+
+interface Theme {
+  name: string;
+  primary: string;
+  secondary: string;
+  accent: string;
+  background: string;
+}
+
+const THEMES: Theme[] = [
+  { name: 'Classic', primary: '#00ff88', secondary: '#ff4444', accent: '#ffaa00', background: '#111' },
+  { name: 'Neon', primary: '#ff00ff', secondary: '#00ffff', accent: '#ffff00', background: '#0a0a0a' },
+  { name: 'Ocean', primary: '#00ced1', secondary: '#4169e1', accent: '#20b2aa', background: '#001f3f' },
+  { name: 'Sunset', primary: '#ff6347', secondary: '#ffa500', accent: '#ff1493', background: '#2b1329' },
+  { name: 'Matrix', primary: '#00ff00', secondary: '#008000', accent: '#90ee90', background: '#000000' }
+];
+
+const ACHIEVEMENTS = [
+  { id: 'first_win', name: 'First Victory', description: 'Win your first game', icon: '🏆' },
+  { id: 'speed_demon', name: 'Speed Demon', description: 'Reach maximum speed', icon: '⚡' },
+  { id: 'power_collector', name: 'Power Collector', description: 'Collect 50 power-ups', icon: '💎' },
+  { id: 'survivor', name: 'Survivor', description: 'Survive for 5 minutes', icon: '⏱️' },
+  { id: 'snake_master', name: 'Snake Master', description: 'Score 1000 points', icon: '👑' }
+];
+
+export const EnhancedMenu: React.FC<EnhancedMenuProps> = ({ onSelectMode }) => {
+  const [currentTheme, setCurrentTheme] = useState<Theme>(THEMES[0]);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showStats, setShowStats] = useState(false);
+  const [showTutorial, setShowTutorial] = useState(false);
+  const [gameStats, setGameStats] = useState<GameStats>({
+    gamesPlayed: 0,
+    highScores: { level1: 0, level2: 0, level3: 0 },
+    totalFoodEaten: 0,
+    totalPowerUpsCollected: 0,
+    achievements: []
+  });
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [particlesEnabled, setParticlesEnabled] = useState(true);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const snakeAnimationRef = useRef<number>();
+
+  // Load saved settings and stats
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('snakeTheme');
+    if (savedTheme) {
+      const theme = THEMES.find(t => t.name === savedTheme) || THEMES[0];
+      setCurrentTheme(theme);
+      applyTheme(theme);
+    }
+
+    const savedStats = localStorage.getItem('snakeGameStats');
+    if (savedStats) {
+      setGameStats(JSON.parse(savedStats));
+    }
+
+    const savedSound = localStorage.getItem('snakeSoundEnabled');
+    setSoundEnabled(savedSound !== 'false');
+
+    const savedParticles = localStorage.getItem('snakeParticlesEnabled');
+    setParticlesEnabled(savedParticles !== 'false');
+  }, []);
+
+  // Apply theme to CSS variables
+  const applyTheme = (theme: Theme) => {
+    const root = document.documentElement;
+    root.style.setProperty('--primary-color', theme.primary);
+    root.style.setProperty('--secondary-color', theme.secondary);
+    root.style.setProperty('--accent-color', theme.accent);
+    root.style.setProperty('--background-color', theme.background);
+  };
+
+  // Animated snake background
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    const snakes: Array<{
+      x: number;
+      y: number;
+      length: number;
+      direction: number;
+      segments: Array<{ x: number; y: number }>;
+      color: string;
+      speed: number;
+    }> = [];
+
+    // Create background snakes
+    for (let i = 0; i < 3; i++) {
+      const snake = {
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        length: 15 + Math.random() * 10,
+        direction: Math.random() * Math.PI * 2,
+        segments: [] as Array<{ x: number; y: number }>,
+        color: i === 0 ? currentTheme.primary : i === 1 ? currentTheme.secondary : currentTheme.accent,
+        speed: 1 + Math.random() * 2
+      };
+
+      // Initialize segments
+      for (let j = 0; j < snake.length; j++) {
+        snake.segments.push({ x: snake.x, y: snake.y });
+      }
+
+      snakes.push(snake);
+    }
+
+    const animate = () => {
+      ctx.fillStyle = currentTheme.background + '20';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      snakes.forEach(snake => {
+        // Update snake position
+        snake.direction += (Math.random() - 0.5) * 0.2;
+        snake.x += Math.cos(snake.direction) * snake.speed;
+        snake.y += Math.sin(snake.direction) * snake.speed;
+
+        // Wrap around screen
+        if (snake.x < 0) snake.x = canvas.width;
+        if (snake.x > canvas.width) snake.x = 0;
+        if (snake.y < 0) snake.y = canvas.height;
+        if (snake.y > canvas.height) snake.y = 0;
+
+        // Update segments
+        snake.segments.unshift({ x: snake.x, y: snake.y });
+        snake.segments.pop();
+
+        // Draw snake
+        ctx.strokeStyle = snake.color + '40';
+        ctx.lineWidth = 8;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        
+        snake.segments.forEach((segment, index) => {
+          if (index === 0) {
+            ctx.moveTo(segment.x, segment.y);
+          } else {
+            ctx.lineTo(segment.x, segment.y);
+          }
+        });
+        
+        ctx.stroke();
+
+        // Draw snake head
+        ctx.fillStyle = snake.color + '80';
+        ctx.beginPath();
+        ctx.arc(snake.x, snake.y, 6, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      snakeAnimationRef.current = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    const handleResize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      if (snakeAnimationRef.current) {
+        cancelAnimationFrame(snakeAnimationRef.current);
+      }
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [currentTheme]);
+
+  const handleThemeChange = (theme: Theme) => {
+    setCurrentTheme(theme);
+    applyTheme(theme);
+    localStorage.setItem('snakeTheme', theme.name);
+  };
+
+  const handleSoundToggle = () => {
+    const newValue = !soundEnabled;
+    setSoundEnabled(newValue);
+    localStorage.setItem('snakeSoundEnabled', newValue.toString());
+  };
+
+  const handleParticlesToggle = () => {
+    const newValue = !particlesEnabled;
+    setParticlesEnabled(newValue);
+    localStorage.setItem('snakeParticlesEnabled', newValue.toString());
+  };
+
+  const startTutorial = () => {
+    setShowTutorial(false);
+    onSelectMode('tutorial');
+  };
+
+  return (
+    <div className="enhanced-menu">
+      <canvas ref={canvasRef} className="menu-background" />
+      
+      <div className="menu-content">
+        <div className="menu-header">
+          <h1 className="game-title">
+            <span className="snake-icon">🐍</span>
+            <span className="title-text">SNAKE EVOLUTION</span>
+            <span className="snake-icon">🐍</span>
+          </h1>
+          <p className="game-subtitle">A Modern Classic Reimagined</p>
+        </div>
+
+        {!showSettings && !showStats && !showTutorial ? (
+          <div className="main-menu">
+            <div className="level-cards">
+              <div className="level-card" onClick={() => onSelectMode('level1')}>
+                <div className="card-icon">🎯</div>
+                <h3>Classic Mode</h3>
+                <p>The timeless snake experience</p>
+                <div className="high-score">Best: {gameStats.highScores.level1}</div>
+              </div>
+
+              <div className="level-card" onClick={() => onSelectMode('level2')}>
+                <div className="card-icon">🧱</div>
+                <h3>Obstacle Course</h3>
+                <p>Navigate through challenging mazes</p>
+                <div className="high-score">Best: {gameStats.highScores.level2}</div>
+              </div>
+
+              <div className="level-card" onClick={() => onSelectMode('level3')}>
+                <div className="card-icon">🤖</div>
+                <h3>AI Battle</h3>
+                <p>Face off against smart opponents</p>
+                <div className="high-score">Best: {gameStats.highScores.level3}</div>
+              </div>
+            </div>
+
+            <div className="menu-actions">
+              <button className="menu-button tutorial-btn" onClick={() => setShowTutorial(true)}>
+                <span className="btn-icon">🎓</span>
+                Tutorial
+              </button>
+              <button className="menu-button stats-btn" onClick={() => setShowStats(true)}>
+                <span className="btn-icon">📊</span>
+                Statistics
+              </button>
+              <button className="menu-button settings-btn" onClick={() => setShowSettings(true)}>
+                <span className="btn-icon">⚙️</span>
+                Settings
+              </button>
+            </div>
+
+            <div className="quick-stats">
+              <div className="stat-item">
+                <span className="stat-icon">🎮</span>
+                <span className="stat-value">{gameStats.gamesPlayed}</span>
+                <span className="stat-label">Games</span>
+              </div>
+              <div className="stat-item">
+                <span className="stat-icon">🍎</span>
+                <span className="stat-value">{gameStats.totalFoodEaten}</span>
+                <span className="stat-label">Food</span>
+              </div>
+              <div className="stat-item">
+                <span className="stat-icon">✨</span>
+                <span className="stat-value">{gameStats.achievements.length}/{ACHIEVEMENTS.length}</span>
+                <span className="stat-label">Achievements</span>
+              </div>
+            </div>
+          </div>
+        ) : showSettings ? (
+          <div className="settings-panel">
+            <h2>Settings</h2>
+            
+            <div className="settings-section">
+              <h3>Theme</h3>
+              <div className="theme-selector">
+                {THEMES.map(theme => (
+                  <div
+                    key={theme.name}
+                    className={`theme-option ${currentTheme.name === theme.name ? 'active' : ''}`}
+                    onClick={() => handleThemeChange(theme)}
+                  >
+                    <div className="theme-preview" style={{
+                      background: `linear-gradient(135deg, ${theme.primary}, ${theme.secondary})`
+                    }} />
+                    <span>{theme.name}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="settings-section">
+              <h3>Game Options</h3>
+              <div className="toggle-option">
+                <span>Sound Effects</span>
+                <button 
+                  className={`toggle-button ${soundEnabled ? 'active' : ''}`}
+                  onClick={handleSoundToggle}
+                >
+                  {soundEnabled ? 'ON' : 'OFF'}
+                </button>
+              </div>
+              <div className="toggle-option">
+                <span>Particle Effects</span>
+                <button 
+                  className={`toggle-button ${particlesEnabled ? 'active' : ''}`}
+                  onClick={handleParticlesToggle}
+                >
+                  {particlesEnabled ? 'ON' : 'OFF'}
+                </button>
+              </div>
+            </div>
+
+            <button className="back-btn" onClick={() => setShowSettings(false)}>
+              ← Back to Menu
+            </button>
+          </div>
+        ) : showStats ? (
+          <div className="stats-panel">
+            <h2>Statistics & Achievements</h2>
+            
+            <div className="stats-grid">
+              <div className="stat-card">
+                <h3>Games Played</h3>
+                <div className="stat-number">{gameStats.gamesPlayed}</div>
+              </div>
+              <div className="stat-card">
+                <h3>Total Food Eaten</h3>
+                <div className="stat-number">{gameStats.totalFoodEaten}</div>
+              </div>
+              <div className="stat-card">
+                <h3>Power-ups Collected</h3>
+                <div className="stat-number">{gameStats.totalPowerUpsCollected}</div>
+              </div>
+              <div className="stat-card">
+                <h3>Best Combined Score</h3>
+                <div className="stat-number">
+                  {gameStats.highScores.level1 + gameStats.highScores.level2 + gameStats.highScores.level3}
+                </div>
+              </div>
+            </div>
+
+            <div className="achievements-section">
+              <h3>Achievements</h3>
+              <div className="achievements-grid">
+                {ACHIEVEMENTS.map(achievement => (
+                  <div 
+                    key={achievement.id}
+                    className={`achievement-card ${gameStats.achievements.includes(achievement.id) ? 'unlocked' : 'locked'}`}
+                  >
+                    <div className="achievement-icon">{achievement.icon}</div>
+                    <div className="achievement-info">
+                      <h4>{achievement.name}</h4>
+                      <p>{achievement.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <button className="back-btn" onClick={() => setShowStats(false)}>
+              ← Back to Menu
+            </button>
+          </div>
+        ) : showTutorial ? (
+          <div className="tutorial-panel">
+            <h2>How to Play</h2>
+            
+            <div className="tutorial-content">
+              <div className="tutorial-section">
+                <h3>🎮 Controls</h3>
+                <p>• Use Arrow Keys or WASD to move</p>
+                <p>• Swipe on mobile devices</p>
+                <p>• Press SPACE to pause</p>
+              </div>
+
+              <div className="tutorial-section">
+                <h3>🎯 Objectives</h3>
+                <p>• Eat food to grow longer</p>
+                <p>• Avoid walls and your own tail</p>
+                <p>• Collect power-ups for special abilities</p>
+              </div>
+
+              <div className="tutorial-section">
+                <h3>⚡ Power-ups</h3>
+                <div className="powerup-list">
+                  <p>⚡ Speed Boost - Move faster</p>
+                  <p>🛡️ Shield - Survive one collision</p>
+                  <p>👻 Ghost Mode - Pass through snakes</p>
+                  <p>💎 Double Points - 2x score</p>
+                  <p>🐌 Slow Motion - Move slower</p>
+                </div>
+              </div>
+
+              <div className="tutorial-section">
+                <h3>💡 Tips</h3>
+                <p>• Plan your path ahead</p>
+                <p>• Use the edges strategically</p>
+                <p>• Collect combos for bonus points</p>
+              </div>
+            </div>
+
+            <div className="tutorial-actions">
+              <button className="menu-button play-tutorial" onClick={startTutorial}>
+                Play Interactive Tutorial
+              </button>
+              <button className="back-btn" onClick={() => setShowTutorial(false)}>
+                ← Back to Menu
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add particle system component for visual effects
- introduce enhanced menu with themes, settings, and tutorial
- wire up new menu and particle settings in App
- update tests for new menu title
- include placeholder tutorial mode component

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c4dfe6fc08329a9cb81668f25b94d