### PR TITLE
Fix ghost mode collision and HUD shift

### DIFF
--- a/src/components/Game/SnakeGame.css
+++ b/src/components/Game/SnakeGame.css
@@ -88,6 +88,7 @@
   gap: 20px;
   font-size: clamp(0.8rem, 2.5vw, 0.9rem);
   color: #88ccff;
+  min-height: 24px;
 }
 
 .player-scores {

--- a/src/components/Game/SnakeGameLevel3.tsx
+++ b/src/components/Game/SnakeGameLevel3.tsx
@@ -310,7 +310,7 @@ const SnakeGameLevel3: React.FC<SnakeGameLevel3Props> = ({ particlesEnabled = fa
 
         // Check collisions
         const selfCollision = currentSnake.some(segment => positionEquals(segment, head));
-        const botCollision = !hasGhostMode(activePowerUps) && 
+        const botCollision = !hasGhostMode(activePowerUps) && !hasGhostMode(botActivePowerUps) &&
                            botSnake.positions.some(segment => positionEquals(segment, head));
         
         if ((selfCollision || botCollision) && !hasInvincibility(activePowerUps)) {
@@ -379,7 +379,7 @@ const SnakeGameLevel3: React.FC<SnakeGameLevel3Props> = ({ particlesEnabled = fa
 
         // Check collisions for bot
         const selfCollision = currentBot.positions.some(segment => positionEquals(segment, head));
-        const playerCollision = !hasGhostMode(botActivePowerUps) && 
+        const playerCollision = !hasGhostMode(botActivePowerUps) && !hasGhostMode(activePowerUps) &&
                               snake.some(segment => positionEquals(segment, head));
         
         if ((selfCollision || playerCollision) && !hasInvincibility(botActivePowerUps)) {


### PR DESCRIPTION
## Summary
- fix moveSnakes collision detection for ghost mode in Level 3
- prevent screen shift when power-ups appear by reserving height

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68887af447d083298909308b88edc9fa